### PR TITLE
Improve contact info grid responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -682,7 +682,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .contact-info {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: var(--spacing-lg);
 }
 
@@ -1023,7 +1023,7 @@ h1, h2, h3, h4, h5, h6 {
     }
 
     .contact-info {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     }
 
     .product-container {
@@ -1096,5 +1096,9 @@ h1, h2, h3, h4, h5, h6 {
 
     .product-actions {
         gap: var(--spacing-sm);
+    }
+
+    .contact-info {
+        gap: var(--spacing-md);
     }
 }


### PR DESCRIPTION
## Summary
- allow contact items to wrap with `auto-fit` grid
- keep responsive grid columns at 768px
- adjust contact spacing on very small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684948997184832ab82375e0cd03f6b1