### PR TITLE
Improve DOM insertion security

### DIFF
--- a/catalog-page-loader.js
+++ b/catalog-page-loader.js
@@ -33,19 +33,41 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             const imageSrc = product.mainImage || 'https://via.placeholder.com/400x300.png?text=ArtDecor';
             const imageAlt = (product.imageAlts && product.imageAlts[0]) ? product.imageAlts[0] : `Изображение ${product.name}`;
-            
+
             let priceDisplay = product.price ? `${product.price} ${product.priceUnit || ''}`.trim() : 'Цена по запросу';
 
-            card.innerHTML = `
-                <img src="${imageSrc}" alt="${imageAlt}" class="catalog-card-image">
-                <div class="catalog-card-content">
-                    <h3 class="catalog-card-title">${product.name}</h3>
-                    <p class="product-card-price">${priceDisplay}</p>
-                    <span class="catalog-card-link">Подробнее <span class="arrow">→</span></span>
-                </div>
-            `;
-            
-            const imgElement = card.querySelector('.catalog-card-image');
+            const img = document.createElement('img');
+            img.src = imageSrc;
+            img.alt = imageAlt;
+            img.className = 'catalog-card-image';
+
+            const content = document.createElement('div');
+            content.className = 'catalog-card-content';
+
+            const title = document.createElement('h3');
+            title.className = 'catalog-card-title';
+            title.textContent = product.name;
+
+            const price = document.createElement('p');
+            price.className = 'product-card-price';
+            price.textContent = priceDisplay;
+
+            const linkSpan = document.createElement('span');
+            linkSpan.className = 'catalog-card-link';
+            linkSpan.textContent = 'Подробнее ';
+            const arrow = document.createElement('span');
+            arrow.className = 'arrow';
+            arrow.textContent = '→';
+            linkSpan.appendChild(arrow);
+
+            content.appendChild(title);
+            content.appendChild(price);
+            content.appendChild(linkSpan);
+
+            card.appendChild(img);
+            card.appendChild(content);
+
+            const imgElement = img;
             imgElement.onerror = function() {
                 this.src = 'https://via.placeholder.com/400x300.png?text=Image+Error';
                 this.alt = 'Ошибка загрузки изображения товара';

--- a/product-loader.js
+++ b/product-loader.js
@@ -55,7 +55,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             document.getElementById('productPriceUnit').textContent = product.priceUnit || '';
             const shortDescElement = document.getElementById('productShortDescription');
             if (shortDescElement) {
-                 shortDescElement.innerHTML = product.shortDescription || '<p>Описание скоро появится.</p>';
+                shortDescElement.textContent = '';
+                const p = document.createElement('p');
+                p.textContent = product.shortDescription || 'Описание скоро появится.';
+                shortDescElement.appendChild(p);
             }
 
             // Fill gallery
@@ -127,10 +130,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Fill full description
             const fullDescriptionContainer = document.getElementById('productFullDescriptionContent');
             if (fullDescriptionContainer) {
+                fullDescriptionContainer.textContent = '';
                 if (product.fullDescription) {
-                    fullDescriptionContainer.innerHTML = product.fullDescription;
+                    fullDescriptionContainer.innerHTML = sanitizeHTML(product.fullDescription);
                 } else {
-                    fullDescriptionContainer.innerHTML = '<p>Подробное описание отсутствует.</p>';
+                    const p = document.createElement('p');
+                    p.textContent = 'Подробное описание отсутствует.';
+                    fullDescriptionContainer.appendChild(p);
                 }
             }
 
@@ -180,13 +186,34 @@ function updateMetaTag(attributeName, attributeValue, content) {
 function displayError(message, pageTitle) {
     const productContainer = document.getElementById('productContainer');
     if (productContainer) {
-        productContainer.innerHTML = `
-            <div class="error-container" style="text-align: center; padding: var(--spacing-xxl); color: var(--muted-text-color);">
-                <h1 style="color: var(--brand-color-gold); margin-bottom: var(--spacing-md);">Ошибка</h1>
-                <p style="font-size: 1.1rem;">${message}</p>
-                <a href="catalog.html" class="btn btn-primary" style="margin-top: var(--spacing-lg);">Вернуться в каталог</a>
-            </div>
-        `;
+        productContainer.textContent = '';
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'error-container';
+        wrapper.style.textAlign = 'center';
+        wrapper.style.padding = 'var(--spacing-xxl)';
+        wrapper.style.color = 'var(--muted-text-color)';
+
+        const title = document.createElement('h1');
+        title.style.color = 'var(--brand-color-gold)';
+        title.style.marginBottom = 'var(--spacing-md)';
+        title.textContent = 'Ошибка';
+
+        const p = document.createElement('p');
+        p.style.fontSize = '1.1rem';
+        p.innerHTML = sanitizeHTML(message);
+
+        const link = document.createElement('a');
+        link.href = 'catalog.html';
+        link.className = 'btn btn-primary';
+        link.style.marginTop = 'var(--spacing-lg)';
+        link.textContent = 'Вернуться в каталог';
+
+        wrapper.appendChild(title);
+        wrapper.appendChild(p);
+        wrapper.appendChild(link);
+
+        productContainer.appendChild(wrapper);
     }
     if (pageTitle) {
         document.title = pageTitle;

--- a/product.html
+++ b/product.html
@@ -171,6 +171,7 @@
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/js/lightbox.min.js"></script>
     <script src="script.js"></script>
+    <script src="sanitizer.js"></script>
     <script src="product-loader.js"></script>
 
     <!-- Product Image Change Function -->

--- a/sanitizer.js
+++ b/sanitizer.js
@@ -1,0 +1,43 @@
+(function (global) {
+    'use strict';
+
+    function sanitizeHTML(htmlString) {
+        const template = document.createElement('template');
+        template.innerHTML = htmlString;
+
+        const allowedTags = ['b', 'i', 'em', 'strong', 'p', 'br', 'ul', 'ol', 'li',
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'span'];
+        const allowedAttrs = {
+            'a': ['href', 'title', 'target', 'rel'],
+            'span': ['class']
+        };
+
+        const sanitizeNode = (node) => {
+            const children = Array.from(node.childNodes);
+            children.forEach(child => sanitizeNode(child));
+
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                const tag = node.tagName.toLowerCase();
+                if (!allowedTags.includes(tag)) {
+                    const fragment = document.createDocumentFragment();
+                    while (node.firstChild) {
+                        fragment.appendChild(node.firstChild);
+                    }
+                    node.parentNode.replaceChild(fragment, node);
+                } else {
+                    [...node.attributes].forEach(attr => {
+                        const allowed = allowedAttrs[tag] || [];
+                        if (!allowed.includes(attr.name.toLowerCase())) {
+                            node.removeAttribute(attr.name);
+                        }
+                    });
+                }
+            }
+        };
+
+        sanitizeNode(template.content);
+        return template.innerHTML;
+    }
+
+    global.sanitizeHTML = sanitizeHTML;
+})(window);


### PR DESCRIPTION
## Summary
- create a simple HTML sanitizer utility
- build catalog cards using DOM methods instead of `innerHTML`
- use text nodes for short descriptions
- sanitize rich product descriptions and error messages
- load sanitizer on product page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494c517668832ab70ada00682874a0