### PR TITLE
Sanitize product description insertion

### DIFF
--- a/catalog-page-loader.js
+++ b/catalog-page-loader.js
@@ -11,14 +11,14 @@ document.addEventListener('DOMContentLoaded', async () => {
             catalogMessage.textContent = message;
             catalogMessage.style.display = 'block';
         }
-        if (productGrid) productGrid.innerHTML = '';
+        if (productGrid) productGrid.textContent = '';
     };
 
     // Function to display products
     const displayProducts = (productsToDisplay) => {
         if (!productGrid || !catalogMessage) return;
         
-        productGrid.innerHTML = '';
+        productGrid.textContent = '';
         catalogMessage.style.display = 'none';
 
         if (productsToDisplay.length === 0) {
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Function to create and display category filters
     const displayCategoryFilters = (products) => {
         if (!categoryFiltersContainer) return;
-        categoryFiltersContainer.innerHTML = '';
+        categoryFiltersContainer.textContent = '';
 
         const categories = ['Все категории', ...new Set(products.map(p => p.category).filter(Boolean))];
 

--- a/product-loader.js
+++ b/product-loader.js
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Fill gallery
             const mainProductImage = document.getElementById('mainProductImage');
             const thumbnailsContainer = document.getElementById('productThumbnails');
-            thumbnailsContainer.innerHTML = ''; 
+            thumbnailsContainer.textContent = '';
 
             mainProductImage.src = product.mainImage || 'https://via.placeholder.com/600x500.png?text=Фото+отсутствует';
             mainProductImage.alt = (product.imageAlts && product.imageAlts[0]) ? product.imageAlts[0] : `${product.name} - основное изображение`;
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Fill characteristics
             const characteristicsList = document.getElementById('characteristicsList');
             if (characteristicsList) {
-                characteristicsList.innerHTML = '';
+                characteristicsList.textContent = '';
                 if (product.characteristics && product.characteristics.length > 0) {
                     product.characteristics.forEach(char => {
                         const dt = document.createElement('dt');
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (fullDescriptionContainer) {
                 fullDescriptionContainer.textContent = '';
                 if (product.fullDescription) {
-                    fullDescriptionContainer.innerHTML = sanitizeHTML(product.fullDescription);
+                    setSanitizedHTML(fullDescriptionContainer, product.fullDescription);
                 } else {
                     const p = document.createElement('p');
                     p.textContent = 'Подробное описание отсутствует.';
@@ -201,7 +201,7 @@ function displayError(message, pageTitle) {
 
         const p = document.createElement('p');
         p.style.fontSize = '1.1rem';
-        p.innerHTML = sanitizeHTML(message);
+        setSanitizedHTML(p, message);
 
         const link = document.createElement('a');
         link.href = 'catalog.html';

--- a/product.html
+++ b/product.html
@@ -173,6 +173,7 @@
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.4/js/lightbox.min.js"></script>
     <script src="script.js"></script>
+    <script src="sanitizer.js"></script>
     <script src="product-loader.js"></script>
 
     <!-- Product Image Change Function -->

--- a/sanitizer.js
+++ b/sanitizer.js
@@ -39,5 +39,15 @@
         return template.innerHTML;
     }
 
+    function setSanitizedHTML(element, htmlString) {
+        element.textContent = '';
+        if (!htmlString) return;
+        const sanitized = sanitizeHTML(htmlString);
+        const template = document.createElement('template');
+        template.innerHTML = sanitized;
+        element.appendChild(template.content.cloneNode(true));
+    }
+
     global.sanitizeHTML = sanitizeHTML;
+    global.setSanitizedHTML = setSanitizedHTML;
 })(window);


### PR DESCRIPTION
## Summary
- add a helper to safely insert sanitized HTML
- use the helper when rendering product descriptions and errors
- clear DOM containers with `textContent`
- include `sanitizer.js` on the product page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684954d4f968832aac46c1d69f1f9aca