### PR TITLE
Add hero video background without placeholder media

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
     <main id="main" class="site-main">
         <!-- Hero Section -->
         <section id="hero" class="hero-section">
+            <video class="hero-bg-video" autoplay muted loop playsinline preload="metadata" poster="images/hero/hero.jpg" aria-hidden="true">
+                <source src="images/hero/hero.mp4" type="video/mp4">
+            </video>
+            <div class="hero-overlay"></div>
             <div class="container">
                 <div class="hero-container">
                     <h1 class="hero-title">

--- a/style.css
+++ b/style.css
@@ -338,6 +338,34 @@ h1, h2, h3, h4, h5, h6 {
     align-items: center;
     justify-content: center;
 }
+.hero-bg-video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: 0;
+    pointer-events: none;
+}
+.hero-overlay {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.45);
+    z-index: 1;
+    pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hero-bg-video {
+        display: none;
+    }
+    .hero-section {
+        background-image: url('images/hero/hero.jpg');
+        background-size: cover;
+        background-position: center;
+    }
+}
 
 .hero-container {
     position: relative;


### PR DESCRIPTION
## Summary
- embed hero background video with an overlay
- style video layer and reduce-motion fallback
- remove placeholder media files so the real assets can be used

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685927788fc8832aa8321b3b7d1263dd